### PR TITLE
Fix pre-commit issues on M1 macs 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,19 @@ repos:
     -   id: pii_secret_filename
         files: ''
         language: python
-        language_version: python3.9
+        language_version: python3.10
         pass_filenames: true
         require_serial: true
     -   id: pii_secret_file_content
         files: ''
         language: python
-        language_version: python3.9
+        language_version: python3.10
         pass_filenames: true
         require_serial: true
     -   id: pii_secret_file_content_ner
         files: ''
         language: python
-        language_version: python3.9
+        language_version: python3.10
         # args: [--ner_output_file=ner_output_file.txt] # uncomment to output NER entities
         pass_filenames: true
         require_serial: true
@@ -30,7 +30,7 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-    language_version: python3.9
+    language_version: python3.10
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/activity_stream/factories.py
+++ b/activity_stream/factories.py
@@ -58,5 +58,5 @@ class ServiceEmailAddressFactory(DjangoModelFactory):
 
     staff_sso_user = factory.SubFactory(ActivityStreamStaffSSOUserFactory)
     service_now_email_address = factory.Sequence(
-        lambda n: f"service.email.address{n}@example.com",
+        lambda n: f"service.email.address{n}@example.com",  # /PS-IGNORE
     )

--- a/core/templates/gtm-body.html
+++ b/core/templates/gtm-body.html
@@ -1,3 +1,3 @@
 {% if COOKIE_RESPONSE == "accept" %}
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> 
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% endif %}

--- a/leavers/tests/views/test_leaver.py
+++ b/leavers/tests/views/test_leaver.py
@@ -426,8 +426,9 @@ class TestConfirmDetailsView(TestCase):
         self.assertEqual(leaver_details["last_name"], "Bloggs")
         self.assertEqual(leaver_details["staff_id"], "12345")
         self.assertEqual(
-            leaver_details["contact_email_address"], "joe.bloggs@example.com"
-        )  # /PS-IGNORE
+            leaver_details["contact_email_address"],
+            "joe.bloggs@example.com",  # /PS-IGNORE
+        )
         self.assertEqual(leaver_details["photo"], "")
 
     @mock.patch(
@@ -544,8 +545,9 @@ class TestUpdateDetailsView(TestCase):
         self.assertEqual(form.initial["job_title"], "Job title")
         self.assertEqual(form.initial["last_name"], "Bloggs")  # /PS-IGNORE
         self.assertEqual(
-            form.initial["contact_email_address"], "joe.bloggs@example.com"
-        )  # /PS-IGNORE
+            form.initial["contact_email_address"],
+            "joe.bloggs@example.com",  # /PS-IGNORE
+        )
         self.assertEqual(form.initial["photo"], "")
 
     def test_existing_updates(self, mock_get_search_results) -> None:

--- a/leavers/tests/views/test_leaver.py
+++ b/leavers/tests/views/test_leaver.py
@@ -651,7 +651,7 @@ class TestUpdateDetailsView(TestCase):
         self.assertEqual(response.url, reverse("leaver-has-cirrus-equipment"))
 
         leaver_updates_obj = models.LeaverInformation.objects.get(
-            personal_email="someone@example.com",
+            personal_email="someone@example.com",  # /PS-IGNORE
         )
         leaver_updates: types.LeaverDetailUpdates = leaver_updates_obj.updates
 

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1,4 +1,5 @@
 -O codecov.sh https://codecov.io/bash
+'None" &&
 " Get Service Now
 " Leavers Workflow This can be triggered in 2
 " Line Manager
@@ -22,6 +23,8 @@
 | SLACK_SRE_CHANNEL_ID                                     | None                                       
 | SLACK_SRE_CHANNEL_ID                                     | None                                       |                                                           
 | TEMPLATE_ID_SECURITY_TEAM_OFFBOARD_LEAVER_REMINDER_EMAIL |
+0003_add_user_user_id
+0007_activitystreamstaffssouser_is_active
 0032_leavingrequest_reason_for_leaving
 100px
 234px
@@ -110,13 +113,16 @@ Example Building
 Example Grade
 expires_at
 f"<a href='{cancel_url
+f"ActivityStreamStaffSSOUser
 f"Asset
+f"Error
 f"Gsuite
 f"Physical Asset
 f"Software Asset
 f"sys_id={sys_id
 f"sys_id={sys_id'
 f"Thank
+f"user{n
 f"We
 F401
 Faulty"
@@ -138,6 +144,7 @@ Google Drive or Sharepoint
 GOVUK PAAS
 GOVUK_NOTIFY_API_KEY
 govuk_paas_access_task_log
+Graphs
 Green Park
 has_cirrus_kit
 HAWK_INCOMING_ACCESS_KEY
@@ -167,6 +174,8 @@ Laptop
 Leaver Email
 Leaver Final Actions Email
 Leaver Final Actions Email |  | X |  | X |  |  |  |
+leaver_activitystream_user__contact_email_address
+leaver_activitystream_user__contact_email_address
 Leaver's Notification Form
 leaverLastDay
 LeaversWorkflow
@@ -207,11 +216,15 @@ ParsedUKSBSPDF"
 Pass notes</h2
 People Data
 People Finder
+People Finder API - '
+People Finder Health Check
+People Finder Health Check"
 people_finder_email
 PEOPLE_FINDER_HAWK_SECRET_KEY
 PEOPLE_FINDER_INTERFACE
 PEOPLE_FINDER_INTERFACE                                  |                                            
 PEOPLE_FINDER_INTERFACE=core.people_finder.interfaces
+people_finder_result["email
 Physical Asset
 PhysicalAsset
 Port Replicator
@@ -219,6 +232,7 @@ Port Replicator'
 Procurement Card
 python manage.py compilescss &&
 python manage.py migrate &&
+Raises
 Reason for Leaving Resignation
 recorded</h1
 Reminder Email
@@ -265,9 +279,11 @@ Software Asset
 Sound Bar'
 Sound Bar"
 Split
+SQL
 SRE
 SRE Reminder Email
 sso_access_task_log
+sso_email_user_id
 staff_details.job_title %
 staff_id"
 STAFF_SSO_ACTIVITY_STREAM_ID
@@ -322,6 +338,7 @@ UKSBS_INTERFACE
 UKSBS_POST_LEAVER_SUBMISSION                             
 UKSBSBase
 UKSBSStubbed
+unique_sso_legacy_user_id
 Unit of Measurement
 Unit of Measurement Hours
 Updated Personal Email
@@ -335,20 +352,3 @@ yet.</p
 You Email
 You Email*
 you.</p
-staff_sso_legacy_id
-people_finder_result["email
-staff_sso_legacy_id
-People Data
-SQL
-People Finder API - '
-People Finder Health Check
-People Finder Health Check"
-leaver_activitystream_user__contact_email_address
-f"Error
-unique_sso_legacy_user_id
-Raises
-f"ActivityStreamStaffSSOUser
-f"user{n
-sso_email_user_id
-0003_add_user_user_id
-0007_activitystreamstaffssouser_is_active

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -146,6 +146,7 @@ GOVUK_NOTIFY_API_KEY
 govuk_paas_access_task_log
 Graphs
 Green Park
+gtm-head.html
 has_cirrus_kit
 HAWK_INCOMING_ACCESS_KEY
 HAWK_INCOMING_SECRET_KEY
@@ -342,6 +343,7 @@ unique_sso_legacy_user_id
 Unit of Measurement
 Unit of Measurement Hours
 Updated Personal Email
+User
 users.</td
 viewBox="0 0 483.2
 visit</li>


### PR DESCRIPTION
There's an issue when trying to run the PII Secrets pre-commit checks on M1 Macs as Spacy doesn't have an ARM build for python 3.9.

```
Traceback (most recent call last):
  File "/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/bin/pii-secret-file-content-ner", line 5, in <module>
    from pii_secret_check_hooks.pii_secret_file_content_ner import main
  File "/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/lib/python3.9/site-packages/pii_secret_check_hooks/pii_secret_file_content_ner.py", line 8, in <module>
    from pii_secret_check_hooks.check_file.ner import CheckForNER
  File "/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/lib/python3.9/site-packages/pii_secret_check_hooks/check_file/ner.py", line 4, in <module>
    import spacy
  File "/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/lib/python3.9/site-packages/spacy/__init__.py", line 14, in <module>
    from . import pipeline  # noqa: F401
  File "/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/lib/python3.9/site-packages/spacy/pipeline/__init__.py", line 1, in <module>
    from .attributeruler import AttributeRuler
  File "/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/lib/python3.9/site-packages/spacy/pipeline/attributeruler.py", line 6, in <module>
    from .pipe import Pipe
ImportError: dlopen(/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/lib/python3.9/site-packages/spacy/pipeline/pipe.cpython-39-darwin.so, 0x0002): tried: '/Users/cameronlamb/.cache/pre-commit/repohc8c08lz/py_env-python3.9/lib/python3.9/site-packages/spacy/pipeline/pipe.cpython-39-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'))
```

Upgrading to use Python 3.10 fixes this.

**Suggestion: upgrade the whole project to 3.10?**