### PR TITLE
Remove non-live logic

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -395,9 +395,6 @@ DJANGO_HAWK = {
 # GPC Return Address
 GPC_RETURN_ADDRESS = env.list("GPC_RETURN_ADDRESS", default=[])
 
-# Process leaving requests
-PROCESS_LEAVING_REQUEST = env.bool("PROCESS_LEAVING_REQUEST", default=True)
-
 DIT_OFFBOARDING_EMAIL = env("DIT_OFFBOARDING_EMAIL", default="")
 JML_TEAM_CONTACT_EMAIL = env("JML_TEAM_CONTACT_EMAIL", default="")
 JML_TEAM_EMAILS = env.list("JML_TEAM_EMAILS", default=[])

--- a/core/lsd_help_desk/interfaces.py
+++ b/core/lsd_help_desk/interfaces.py
@@ -50,12 +50,6 @@ class LSDHelpDesk(LSDHelpDeskBase):
             raise Exception("No leaving date is set on the Leaving Request")
         leaving_date_str = leaving_date.strftime(DATE_FORMAT_STR)
 
-        if not settings.PROCESS_LEAVING_REQUEST:
-            logger.warning(
-                f"Creating help desk ticket for LSD team regarding {leaver_name}"
-            )
-            return None
-
         # Create a helpdesk /PS-IGNORE
         comment_body = (
             "We have been informed that the following person is "

--- a/core/notify.py
+++ b/core/notify.py
@@ -103,10 +103,7 @@ def email(
     )
 
     # Send all emails to the JML team
-    if settings.PROCESS_LEAVING_REQUEST:
-        email_addresses += settings.JML_TEAM_EMAILS
-    else:
-        email_addresses = settings.JML_TEAM_EMAILS
+    email_addresses += settings.JML_TEAM_EMAILS
 
     for email_address in email_addresses:
         message_response = notification_client.send_email_notification(

--- a/core/service_now/interfaces.py
+++ b/core/service_now/interfaces.py
@@ -358,11 +358,6 @@ class ServiceNowInterface(ServiceNowBase):
         leaver_details: leavers_types.LeaverDetails,
         assets: List[types.AssetDetails],
     ):
-        if not settings.PROCESS_LEAVING_REQUEST:
-            full_name = leaver_details["first_name"] + " " + leaver_details["last_name"]
-            logger.warning(f"Submitting leaver request to Service Now for {full_name}")
-            return None
-
         leaving_request: "LeavingRequest" = leaver_info.leaving_request
 
         leaver_email = leaving_request.get_leaver_email()

--- a/core/uksbs/interfaces.py
+++ b/core/uksbs/interfaces.py
@@ -1,8 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
 
-from django.conf import settings
-
 from core.uksbs.client import UKSBSClient
 from core.uksbs.types import LeavingData, PersonHierarchyData
 
@@ -113,8 +111,4 @@ class UKSBSInterface(UKSBSBase):
         Submit the leaver form to inform UK SBS of a leaver.
         """
 
-        if not settings.PROCESS_LEAVING_REQUEST:
-            leaver_name = data["templateData"]["leaverEmail"]
-            logger.warning(f"Submitting leaving data to UK SBS for {leaver_name}")
-            return None
         self.client.post_leaver_form(data=data)

--- a/docs/technical-documentation/environment-variables.md
+++ b/docs/technical-documentation/environment-variables.md
@@ -44,7 +44,6 @@
 | UKSBS_GET_PEOPLE_HIERARCHY                                       | None                                       | UK SBS People Hierarchy path                                                                           |
 | UKSBS_LEAVER_SUBMISSION_API_URL                                  | None                                       | UK SBS Leaver Submission URL                                                                           |
 | UKSBS_POST_LEAVER_SUBMISSION                                     | None                                       | UK SBS Leaver Submission path                                                                          |
-| PROCESS_LEAVING_REQUEST                                          | true                                       | Set to 'false' if you want to prevent sending leaving request data to the processors.                  |
 | GPC_RETURN_ADDRESS                                               | []                                         | Set as the comma separated list of each address line for the GPC Return Address                        |
 | TEMPLATE_ID_LEAVER_THANK_YOU_EMAIL                               | None                                       |                                                                                                        |
 | TEMPLATE_ID_LEAVER_NOT_IN_UKSBS_HR_REMINDER                      | None                                       |                                                                                                        |


### PR DESCRIPTION
The PROCESS_LEAVING_REQUEST was initially in place to prevent us from sending our test data to real services, but still use production settings.

This is no longer necessary as all submissions through this service are now REAL