### PR TITLE
JMLL-1209 Fix staff documents

### DIFF
--- a/core/management/commands/uuids_for_all_indexed_staff.py
+++ b/core/management/commands/uuids_for_all_indexed_staff.py
@@ -2,7 +2,7 @@
 Make sure all staff indexed in opensearch have a uuid set.
 """
 
-from typing import List
+from typing import Dict, List
 
 from django.core.management.base import BaseCommand
 from opensearch_dsl import Search
@@ -36,7 +36,7 @@ class Command(BaseCommand):
 
     def get_all_staff_documents(self) -> List[StaffDocument]:
         search_client = get_search_connection()
-        search_dict = {"query": {"match_all": {}}}
+        search_dict: Dict = {"query": {"match_all": {}}}
 
         search = (
             Search(index=STAFF_INDEX_NAME)

--- a/core/management/commands/uuids_for_all_indexed_staff.py
+++ b/core/management/commands/uuids_for_all_indexed_staff.py
@@ -1,0 +1,51 @@
+"""
+Make sure all staff indexed in opensearch have a uuid set.
+"""
+
+from typing import List
+
+from django.core.management.base import BaseCommand
+from opensearch_dsl import Search
+
+from core.utils.staff_index import (
+    STAFF_INDEX_NAME,
+    StaffDocument,
+    get_search_connection,
+    update_staff_document,
+)
+
+
+class Command(BaseCommand):
+    help = "Ingest Staff SSO Activity Stream"
+
+    def handle(self, *args, **options) -> None:
+        staff_documents_to_update = self.get_all_staff_documents()
+        for staff_document in staff_documents_to_update:
+            if staff_document.uuid:
+                continue
+            if not staff_document.staff_sso_email_user_id:
+                continue
+
+            # Calling update_staff_document with a document that has no uuid,
+            # will have one generated.
+            update_staff_document(
+                staff_document.staff_sso_email_user_id,
+                staff_document=staff_document.to_dict(),
+                upsert=False,
+            )
+
+    def get_all_staff_documents(self) -> List[StaffDocument]:
+        search_client = get_search_connection()
+        search_dict = {"query": {"match_all": {}}}
+
+        search = (
+            Search(index=STAFF_INDEX_NAME)
+            .using(search_client)
+            .update_from_dict(search_dict)
+        )
+        search_results = search.execute()
+
+        return [
+            StaffDocument.from_dict(hit.to_dict(), infer_missing=True)
+            for hit in search_results.hits
+        ]

--- a/core/utils/staff_index.py
+++ b/core/utils/staff_index.py
@@ -430,7 +430,6 @@ def build_staff_document(*, staff_sso_user: ActivityStreamStaffSSOUser):
     }
 
     staff_document_dict: Dict[str, Any] = {
-        "uuid": str(uuid.uuid4()),
         # Staff SSO
         **staff_sso_data,
         # People Finder
@@ -439,7 +438,7 @@ def build_staff_document(*, staff_sso_user: ActivityStreamStaffSSOUser):
         **get_service_now_data(staff_sso_user=staff_sso_user),
     }
 
-    return StaffDocument.from_dict(staff_document_dict)
+    return StaffDocument.from_dict(staff_document_dict, infer_missing=True)
 
 
 def get_csd_for_activitystream_user(
@@ -476,6 +475,9 @@ def update_staff_document(
 ) -> None:
     """Update the related staff document in the staff search index."""
     search_client = get_search_connection()
+
+    if "uuid" not in staff_document or not staff_document["uuid"]:
+        staff_document["uuid"] = str(uuid.uuid4())
 
     body = {"doc": staff_document}
 


### PR DESCRIPTION
The staff index changes didn't account for adding a `uuid` value to each of the new documents.
This PR sees to fix the following:
 - All new documents will have a UUID added to them
 - All existing documents can be updated to add a UUID if they don't currently have one