### PR TITLE
We no longer send the email about security clearances to CLU4

### DIFF
--- a/core/notify.py
+++ b/core/notify.py
@@ -44,7 +44,7 @@ class EmailTemplates(Enum):
         email_template_settings.LINE_MANAGER_OFFLINE_SERVICE_NOW_EMAIL
     )
 
-    CLU4_LEAVER_EMAIL = email_template_settings.CLU4_EMAIL
+    SECURITY_CLEARANCE_LEAVER_EMAIL = email_template_settings.CLU4_EMAIL
     FEETHAM_SECURITY_PASS_OFFICE_EMAIL = (
         email_template_settings.FEETHAM_SECURITY_PASS_OFFICE_EMAIL
     )

--- a/docs/technical-documentation/emails.md
+++ b/docs/technical-documentation/emails.md
@@ -35,7 +35,7 @@ These are notification emails sent to the processor:
 
 | Email name | Template ID Environment Variable | Context/Notes |
 | ----- | ----- | ----- |
-| CLU4 Leaver Notification Email | TEMPLATE_ID_CLU4_EMAIL | This email is sent to CLU4 to inform them of the leaver. |
+| Security Clearance Leaver Email | TEMPLATE_ID_CLU4_EMAIL | This email is sent vetting to inform them of the leaver. |
 | Feetham Security Pass Office Leaver Notification Email | TEMPLATE_ID_FEETHAM_SECURITY_PASS_OFFICE_EMAIL | This email is sent to the Feetham Security Pass Office to inform them of the leaver and their reported assets. |
 | IT Ops Leaver Notification Email | TEMPLATE_ID_IT_OPS_ASSET_EMAIL | This email is sent to the IT Ops team to inform them of the leaver and their reported assets. |
 | OCS Leaver Notification Email | TEMPLATE_ID_OCS_LEAVER_EMAIL | This email is sent to OCS to inform them of the leaver. |

--- a/leavers/utils/emails.py
+++ b/leavers/utils/emails.py
@@ -219,16 +219,13 @@ def send_leaver_not_in_uksbs_reminder(
     )
 
 
-def send_clu4_leaver_email(
+def send_security_clearance_leaver_email(
     leaving_request: LeavingRequest,
     template_id: Optional[notify.EmailTemplates] = None,
 ):
     """
-    Send Cluster 4 Email to notify of a new leaver.
+    Send email to get security clearances updated.
     """
-
-    if not settings.CLU4_EMAIL:
-        raise ValueError("CLU4_EMAIL is not set")
 
     if not settings.SECURITY_TEAM_VETTING_EMAIL:
         raise ValueError("SECURITY_TEAM_VETTING_EMAIL is not set")
@@ -236,8 +233,8 @@ def send_clu4_leaver_email(
     personalisation = get_leaving_request_email_personalisation(leaving_request)
 
     notify.email(
-        email_addresses=[settings.CLU4_EMAIL, settings.SECURITY_TEAM_VETTING_EMAIL],
-        template_id=notify.EmailTemplates.CLU4_LEAVER_EMAIL,
+        email_addresses=[settings.SECURITY_TEAM_VETTING_EMAIL],
+        template_id=notify.EmailTemplates.SECURITY_CLEARANCE_LEAVER_EMAIL,
         personalisation=personalisation,
     )
 

--- a/leavers/workflow/leaving.py
+++ b/leavers/workflow/leaving.py
@@ -218,7 +218,7 @@ LeaversWorkflow = Workflow(
                 "are_all_tasks_complete",
             ],
             task_info={
-                "email_id": EmailIds.CLU4_EMAIL.value,
+                "email_id": EmailIds.SECURITY_CLEARANCE_EMAIL.value,
             },
         ),
         # OCS

--- a/leavers/workflow/tasks.py
+++ b/leavers/workflow/tasks.py
@@ -426,7 +426,7 @@ class EmailIds(Enum):
 
     FEETHAM_SECURITY_PASS_OFFICE_EMAIL = "feetham_security_pass_office_email"
     IT_OPS_ASSET_EMAIL = "it_ops_asset_email"
-    CLU4_EMAIL = "clu4_email"
+    SECURITY_CLEARANCE_EMAIL = "clu4_email"
     OCS_EMAIL = "ocs_email"
     OCS_OAB_LOCKER_EMAIL = "ocs_oab_locker_email"
     HEALTH_AND_SAFETY_EMAIL = "health_and_safety_email"

--- a/leavers/workflow/tasks.py
+++ b/leavers/workflow/tasks.py
@@ -24,7 +24,6 @@ from leavers.types import LeavingReason, ReminderEmailDict
 from leavers.utils.emails import (
     get_leaving_request_email_personalisation,
     send_buisness_continuity_leaver_email,
-    send_clu4_leaver_email,
     send_comaea_email,
     send_feetham_security_pass_office_email,
     send_health_and_safety_email,
@@ -40,6 +39,7 @@ from leavers.utils.emails import (
     send_line_manager_thankyou_email,
     send_ocs_leaver_email,
     send_ocs_oab_locker_email,
+    send_security_clearance_leaver_email,
     send_security_team_offboard_bp_leaver_email,
     send_security_team_offboard_rk_leaver_email,
 )
@@ -448,7 +448,7 @@ EMAIL_MAPPING: Dict[EmailIds, Callable] = {
     EmailIds.SECURITY_OFFBOARD_RK_LEAVER_NOTIFICATION: send_security_team_offboard_rk_leaver_email,
     EmailIds.FEETHAM_SECURITY_PASS_OFFICE_EMAIL: send_feetham_security_pass_office_email,
     EmailIds.IT_OPS_ASSET_EMAIL: send_it_ops_asset_email,
-    EmailIds.CLU4_EMAIL: send_clu4_leaver_email,
+    EmailIds.SECURITY_CLEARANCE_EMAIL: send_security_clearance_leaver_email,
     EmailIds.OCS_EMAIL: send_ocs_leaver_email,
     EmailIds.OCS_OAB_LOCKER_EMAIL: send_ocs_oab_locker_email,
     EmailIds.HEALTH_AND_SAFETY_EMAIL: send_health_and_safety_email,


### PR DESCRIPTION
- Stop sending the email about updating security clearances to CLU4
- Rename the function to be task oriented
- Rename the mappings
- Don't change the env vars