### PR TITLE
JMLL-1359 Comaea leaving emails sometimes don't send

### DIFF
--- a/leavers/workflow/tasks.py
+++ b/leavers/workflow/tasks.py
@@ -117,7 +117,7 @@ class PauseTask(LeavingRequestTask):
     def should_pause(self, task_info) -> bool:
         pass_condition: str = task_info.get("pass_condition", "")
         if pass_condition == "after_leaving_date" and self.leaving_request.leaving_date:
-            return timezone.now() > self.leaving_request.leaving_date
+            return timezone.now() < self.leaving_request.leaving_date
         return True
 
     def execute(self, task_info):

--- a/leavers/workflow/tests/test_leaving_workflow.py
+++ b/leavers/workflow/tests/test_leaving_workflow.py
@@ -342,7 +342,6 @@ class TestLeaversWorkflow(TestCase):
             "have_sre_carried_out_leaving_tasks",
             "has_line_manager_updated_service_now",
             "are_all_tasks_complete",
-            "notify_comaea_team",
             "have_security_carried_out_bp_leaving_tasks",
             "have_security_carried_out_rk_leaving_tasks",
             "send_sre_reminder",


### PR DESCRIPTION
Reverse the condition as it should return pause as `True` if the current datetime is LESS than the leaving date.
